### PR TITLE
Add preview indicator with exit link

### DIFF
--- a/src/components/PreviewIndicator.tsx
+++ b/src/components/PreviewIndicator.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from 'next/router';
+
+const PreviewIndicator: React.FC = () => {
+  const router = useRouter();
+  const exitLink = `/api/exit-preview?path=${router.asPath}`;
+  return (
+    <div className="preview-indicator">
+      <a href={exitLink} className="exit-link">
+        Exit preview mode
+      </a>
+      <style jsx>{`
+        .preview-indicator {
+          position: fixed;
+          bottom: 0;
+          left: 0;
+          right: 0;
+          z-index: 1;
+          background: var(--color-red);
+          text-align: center;
+          color: white;
+        }
+
+        .exit-link {
+          color: white;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default PreviewIndicator;

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -20,6 +20,7 @@ import { siteName } from '../config';
 interface Props {
   page: ContentfulPage | null;
   sidebar: ContentfulSidebar | null;
+  preview: boolean;
 }
 
 const StandardPage: NextPage<Props> = ({ page, sidebar }) => {
@@ -55,13 +56,16 @@ const StandardPage: NextPage<Props> = ({ page, sidebar }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({ params, preview }) => {
+export const getStaticProps: GetStaticProps = async ({
+  params,
+  preview = false,
+}) => {
   const slug = params!.slug!;
   const [page, sidebar] = await Promise.all([
     fetchPage(slug, preview),
     fetchSidebar(slug, preview),
   ]);
-  return { props: { page, sidebar } };
+  return { props: { page, sidebar, preview } };
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -16,6 +16,7 @@ import HeroImage from '../components/HeroImage';
 import ContentBlock from '../components/ContentBlock';
 import MainContent from '../components/MainContent';
 import { siteName } from '../config';
+import { ParsedUrlQuery } from 'querystring';
 
 interface Props {
   page: ContentfulPage | null;
@@ -56,11 +57,15 @@ const StandardPage: NextPage<Props> = ({ page, sidebar }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({
+interface Query extends ParsedUrlQuery {
+  slug: string[];
+}
+
+export const getStaticProps: GetStaticProps<Props, Query> = async ({
   params,
   preview = false,
 }) => {
-  const slug = params!.slug!;
+  const slug = params!.slug;
   const [page, sidebar] = await Promise.all([
     fetchPage(slug, preview),
     fetchSidebar(slug, preview),
@@ -68,7 +73,7 @@ export const getStaticProps: GetStaticProps = async ({
   return { props: { page, sidebar, preview } };
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths<Query> = async () => {
   const pages = await fetchPages();
   const paths = pages.map((page) => ({
     params: { slug: page.slug.split('/') },

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import Layout from '../components/Layout';
 import Header from '../components/Header';
 import Router from 'next/router';
 import { pageview } from '../lib/gtag';
+import PreviewIndicator from '../components/PreviewIndicator';
 
 dayjs.extend(LocalizedFormat);
 dayjs.locale('sv');
@@ -18,6 +19,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <Layout>
       <Header />
+      {pageProps.preview && <PreviewIndicator />}
       <Component {...pageProps} />
     </Layout>
   );

--- a/src/pages/api/exit-preview.ts
+++ b/src/pages/api/exit-preview.ts
@@ -2,6 +2,6 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   res.clearPreviewData();
-  res.writeHead(307, { Location: '/' });
+  res.writeHead(307, { Location: req.query.path ?? '/' });
   res.end();
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,6 +21,7 @@ interface Props {
   page: ContentfulPage | null;
   sidebar: ContentfulSidebar | null;
   posts: ContentfulPost[] | null;
+  preview: boolean;
 }
 
 const HomePage: NextPage<Props> = ({ page, sidebar, posts }) => {
@@ -60,13 +61,13 @@ const HomePage: NextPage<Props> = ({ page, sidebar, posts }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({ preview }) => {
+export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   const [page, sidebar, posts] = await Promise.all([
     fetchPage('hem', preview),
     fetchSidebar('hem', preview),
     fetchPosts(preview),
   ]);
-  return { props: { page, sidebar, posts } };
+  return { props: { page, sidebar, posts, preview } };
 };
 
 export default HomePage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -61,7 +61,9 @@ const HomePage: NextPage<Props> = ({ page, sidebar, posts }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
+export const getStaticProps: GetStaticProps<Props> = async ({
+  preview = false,
+}) => {
   const [page, sidebar, posts] = await Promise.all([
     fetchPage('hem', preview),
     fetchSidebar('hem', preview),

--- a/src/pages/kontakt.tsx
+++ b/src/pages/kontakt.tsx
@@ -15,6 +15,7 @@ import { siteName } from '../config';
 interface Props {
   contacts: ContentfulContact[];
   sidebar: ContentfulSidebar | null;
+  preview: boolean;
 }
 
 const ContactPage: NextPage<Props> = ({ contacts, sidebar }) => (
@@ -51,12 +52,12 @@ const ContactPage: NextPage<Props> = ({ contacts, sidebar }) => (
   </MainContent>
 );
 
-export const getStaticProps: GetStaticProps = async ({ preview }) => {
+export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
   const [contacts, sidebar] = await Promise.all([
     fetchContacts(preview),
     fetchSidebar('kontakt', preview),
   ]);
-  return { props: { contacts, sidebar } };
+  return { props: { contacts, sidebar, preview } };
 };
 
 export default ContactPage;

--- a/src/pages/kontakt.tsx
+++ b/src/pages/kontakt.tsx
@@ -52,7 +52,9 @@ const ContactPage: NextPage<Props> = ({ contacts, sidebar }) => (
   </MainContent>
 );
 
-export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
+export const getStaticProps: GetStaticProps<Props> = async ({
+  preview = false,
+}) => {
   const [contacts, sidebar] = await Promise.all([
     fetchContacts(preview),
     fetchSidebar('kontakt', preview),

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -12,6 +12,7 @@ import HeroImage from '../../components/HeroImage';
 import ContentBlock from '../../components/ContentBlock';
 import MainContent from '../../components/MainContent';
 import { siteName } from '../../config';
+import { ParsedUrlQuery } from 'querystring';
 
 interface Props {
   post: ContentfulPost | null;
@@ -73,7 +74,11 @@ const PostPage: NextPage<Props> = ({ post, posts }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({
+interface Query extends ParsedUrlQuery {
+  slug: string;
+}
+
+export const getStaticProps: GetStaticProps<Props, Query> = async ({
   params,
   preview = false,
 }) => {
@@ -85,7 +90,7 @@ export const getStaticProps: GetStaticProps = async ({
   return { props: { post, posts, preview } };
 };
 
-export const getStaticPaths: GetStaticPaths = async () => {
+export const getStaticPaths: GetStaticPaths<Query> = async () => {
   const posts = await fetchPosts();
   const paths = posts.map((post) => ({ params: { slug: post.slug } }));
   return { paths, fallback: false };

--- a/src/pages/post/[slug].tsx
+++ b/src/pages/post/[slug].tsx
@@ -16,6 +16,7 @@ import { siteName } from '../../config';
 interface Props {
   post: ContentfulPost | null;
   posts: ContentfulPost[] | null;
+  preview: boolean;
 }
 
 const PostPage: NextPage<Props> = ({ post, posts }) => {
@@ -72,13 +73,16 @@ const PostPage: NextPage<Props> = ({ post, posts }) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({ params, preview }) => {
+export const getStaticProps: GetStaticProps = async ({
+  params,
+  preview = false,
+}) => {
   const slug = params!.slug!;
   const [post, posts] = await Promise.all([
     fetchPost(slug, preview),
     fetchPosts(),
   ]);
-  return { props: { post, posts } };
+  return { props: { post, posts, preview } };
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {


### PR DESCRIPTION
For some reason, preview mode causes an internal server error on some pages in the preview deployment, so it's difficult to test this.