### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,12 +30,7 @@ const Header: React.FC = () => {
         </Link>
         <div className={styles.title}>Scoutkåren Munksnäs Spejarna</div>
         <div className={styles.shortTitle}>Munksnäs Spejarna</div>
-        <button
-          className={styles.menuToggle}
-          onClick={toggleMenu}
-          aria-expanded={menuOpen}
-          aria-controls="main-nav"
-        >
+        <button className={styles.menuToggle} onClick={toggleMenu} aria-expanded={menuOpen} aria-controls="main-nav">
           Meny
         </button>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Menu from './Menu';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { siteName } from '../config';
 import styles from './Header.module.css';
@@ -11,7 +11,16 @@ import logo from '@/assets/msp_logo.svg';
 const Header: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const toggleMenu = () => setMenuOpen(!menuOpen);
-  const closeMenu = () => setMenuOpen(false);
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeMenu();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [menuOpen, closeMenu]);
 
   return (
     <header>
@@ -21,7 +30,12 @@ const Header: React.FC = () => {
         </Link>
         <div className={styles.title}>Scoutkåren Munksnäs Spejarna</div>
         <div className={styles.shortTitle}>Munksnäs Spejarna</div>
-        <button className={styles.menuToggle} onClick={toggleMenu}>
+        <button
+          className={styles.menuToggle}
+          onClick={toggleMenu}
+          aria-expanded={menuOpen}
+          aria-controls="main-nav"
+        >
           Meny
         </button>
       </div>

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -26,7 +26,7 @@ const Menu: React.FC<Props> = ({ open, onClose }) => {
   }
 
   return (
-    <nav className={styles.root} data-mobile-open={open}>
+    <nav id="main-nav" className={styles.root} data-mobile-open={open}>
       {links.map(({ href, label, exact }) => (
         <Link
           className={styles.navLink}


### PR DESCRIPTION
## Summary
- Add `aria-expanded` and `aria-controls` to the menu toggle button so screen readers announce whether the menu is open or closed
- Add `id="main-nav"` to the `<nav>` element to satisfy the `aria-controls` reference
- Close the mobile menu when the user presses Escape, so keyboard users can dismiss it without tabbing through all links

## Test plan
- [ ] Open the mobile menu and verify `aria-expanded="true"` is set on the button
- [ ] Close the menu and verify `aria-expanded="false"`
- [ ] Press Escape while the menu is open and verify it closes
- [ ] Test with a screen reader (VoiceOver) to confirm the menu state is announced