### PR TITLE
Harden npm supply chain security

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,7 @@ ignoredBuiltDependencies:
 
 onlyBuiltDependencies:
   - '@vercel/speed-insights'
+
+minimumReleaseAge: 4320
+blockExoticSubdeps: true
+trustPolicy: no-downgrade

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:earlyMondays"],
+  "extends": ["config:base", "schedule:earlyMondays", "security:minimumReleaseAgeNpm"],
   "timezone": "Europe/Helsinki",
   "semanticCommits": "disabled",
   "labels": ["dependencies"],


### PR DESCRIPTION
Add pnpm supply chain protections: 3-day minimum release age, block exotic subdeps, no-downgrade trust policy, and Renovate npm cooldown preset.