### PR TITLE
Fix invalid Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "schedule:earlyMondays", "security:minimumReleaseAgeNpm"],
+  "extends": ["config:recommended", "schedule:earlyMondays", "security:minimumReleaseAgeNpm"],
   "timezone": "Europe/Helsinki",
   "semanticCommits": "disabled",
   "labels": ["dependencies"],
@@ -11,9 +11,8 @@
     {
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "matchPackagePatterns": ["*"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "excludePackagePatterns": ["typescript", "pnpm"]
+      "matchPackageNames": ["!/typescript/", "!/pnpm/"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ]
 }


### PR DESCRIPTION
Fixes the invalid Renovate config reported in #227.

- Replace deprecated `matchPackagePatterns`/`excludePackagePatterns` with `matchPackageNames` exclusion patterns
- Migrate `config:base` preset to `config:recommended`
- Validated with `renovate-config-validator`

Closes #227