### PR TITLE
Show subpages in expandable mobile menu

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -7,6 +7,7 @@
   --color-menu: #c62127;
   --color-menu-hover: #de3c41;
   --color-menu-active: #9a1a1e;
+  --color-menu-accent: #e7cd0f;
   --color-border: #ddd;
   --color-shading: #f8f8f8;
 }
@@ -19,6 +20,7 @@
     --color-menu: #9e1a1f;
     --color-menu-hover: #b73a3e;
     --color-menu-active: #7b1518;
+    --color-menu-accent: #c9b30d;
     --color-border: #2b2f31;
     --color-shading: #262a2b;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,8 @@ import { Metadata, Viewport } from 'next';
 import { Alegreya, Alegreya_Sans } from 'next/font/google';
 import clsx from 'clsx';
 import { draftMode } from 'next/headers';
+import { fetchPages } from '@/contentful/data';
+import { getMenuSubpages } from '@/utils/navigationUtils';
 import GoogleAnalytics from '@/components/GoogleAnalytics';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import './global.css';
@@ -48,12 +50,13 @@ const alegreyaSans = Alegreya_Sans({
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const { isEnabled } = await draftMode();
+  const pages = await fetchPages(isEnabled);
 
   return (
     <html lang="sv" className={clsx(alegreya.variable, alegreyaSans.variable)}>
       <body>
         <Layout>
-          <Header />
+          <Header subpages={getMenuSubpages(pages)} />
           {isEnabled && <PreviewIndicator />}
           {children}
           <Analytics />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,8 +15,19 @@ interface Props {
 
 const Header: React.FC<Props> = ({ subpages }) => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const toggleMenu = () => setMenuOpen(!menuOpen);
-  const closeMenu = () => setMenuOpen(false);
+  // Animate when toggling with the menu button, but close instantly when
+  // navigating so the collapse doesn't shift the scroll position of the new page
+  const [animate, setAnimate] = useState(true);
+
+  const toggleMenu = () => {
+    setAnimate(true);
+    setMenuOpen(!menuOpen);
+  };
+
+  const closeMenu = () => {
+    setAnimate(false);
+    setMenuOpen(false);
+  };
 
   return (
     <header>
@@ -30,7 +41,7 @@ const Header: React.FC<Props> = ({ subpages }) => {
           Meny
         </button>
       </div>
-      <Menu open={menuOpen} onClose={closeMenu} subpages={subpages} />
+      <Menu open={menuOpen} onClose={closeMenu} animate={animate} subpages={subpages} />
     </header>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,8 +7,13 @@ import { siteName } from '../config';
 import styles from './Header.module.css';
 import Image from 'next/image';
 import logo from '@/assets/msp_logo.svg';
+import { MenuSubpages } from '@/utils/navigationUtils';
 
-const Header: React.FC = () => {
+interface Props {
+  subpages: MenuSubpages;
+}
+
+const Header: React.FC<Props> = ({ subpages }) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const toggleMenu = () => setMenuOpen(!menuOpen);
   const closeMenu = () => setMenuOpen(false);
@@ -25,7 +30,7 @@ const Header: React.FC = () => {
           Meny
         </button>
       </div>
-      <Menu open={menuOpen} onClose={closeMenu} />
+      <Menu open={menuOpen} onClose={closeMenu} subpages={subpages} />
     </header>
   );
 };

--- a/src/components/Menu.module.css
+++ b/src/components/Menu.module.css
@@ -1,17 +1,39 @@
+/* Expand/collapse animations use the grid-template-rows 0fr/1fr technique,
+   which works in all modern browsers unlike transitions to height: auto */
+
 .root {
-  display: none;
-  flex-direction: column;
-  background: var(--color-menu);
-  border-radius: 0.5rem;
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s ease;
 
   &[data-mobile-open='true'] {
-    display: flex;
+    grid-template-rows: 1fr;
   }
 
   @media (--lg) {
-    display: flex;
+    grid-template-rows: 1fr;
+  }
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--color-menu);
+  border-radius: 0.5rem;
+  /* Keep collapsed menu links out of the tab order; visibility transitions
+     discretely so the menu stays visible while collapsing */
+  visibility: hidden;
+  transition: visibility 0.25s;
+
+  [data-mobile-open='true'] > & {
+    visibility: visible;
+  }
+
+  @media (--lg) {
     flex-direction: row;
+    visibility: visible;
   }
 }
 
@@ -87,13 +109,33 @@
   }
 }
 
-.subList {
-  display: flex;
-  flex-direction: column;
-  background: var(--color-menu-active);
+.subListWrapper {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.25s ease;
+
+  &[data-expanded='true'] {
+    grid-template-rows: 1fr;
+  }
 
   @media (--lg) {
     display: none;
+  }
+}
+
+.subList {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--color-menu-active);
+  visibility: hidden;
+  transition: visibility 0.25s;
+
+  /* inherit rather than visible so links stay hidden while the whole
+     mobile menu is closed */
+  [data-expanded='true'] > & {
+    visibility: inherit;
   }
 }
 
@@ -110,5 +152,15 @@
 
   &[aria-current='page'] {
     box-shadow: inset 0.25rem 0 0 var(--color-menu-accent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .root,
+  .nav,
+  .subListWrapper,
+  .subList,
+  .chevron {
+    transition: none;
   }
 }

--- a/src/components/Menu.module.css
+++ b/src/components/Menu.module.css
@@ -6,6 +6,11 @@
   grid-template-rows: 0fr;
   transition: grid-template-rows 0.25s ease;
 
+  &[data-animate='false'],
+  &[data-animate='false'] .nav {
+    transition: none;
+  }
+
   &[data-mobile-open='true'] {
     grid-template-rows: 1fr;
   }

--- a/src/components/Menu.module.css
+++ b/src/components/Menu.module.css
@@ -50,7 +50,11 @@
   }
 
   &[aria-current='page'] {
-    background: var(--color-menu-active);
+    box-shadow: inset 0.25rem 0 0 white;
+
+    @media (--lg) {
+      box-shadow: inset 0 -0.25rem 0 white;
+    }
   }
 }
 
@@ -105,6 +109,6 @@
   }
 
   &[aria-current='page'] {
-    font-weight: bold;
+    box-shadow: inset 0.25rem 0 0 white;
   }
 }

--- a/src/components/Menu.module.css
+++ b/src/components/Menu.module.css
@@ -15,9 +15,87 @@
   }
 }
 
+.group {
+  display: flex;
+  flex-direction: column;
+
+  @media (--lg) {
+    display: contents;
+  }
+}
+
+.groupHeader {
+  display: flex;
+  align-items: stretch;
+
+  @media (--lg) {
+    display: contents;
+  }
+}
+
 .navLink {
   display: block;
+  flex: 1;
   padding: 0.5rem 1rem;
+  color: white;
+  text-decoration: none;
+  transition: background 0.2s;
+
+  @media (--lg) {
+    flex: initial;
+  }
+
+  &:hover {
+    background: var(--color-menu-hover);
+  }
+
+  &[aria-current='page'] {
+    background: var(--color-menu-active);
+  }
+}
+
+.expandToggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  color: white;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--color-menu-hover);
+  }
+
+  @media (--lg) {
+    display: none;
+  }
+}
+
+.chevron {
+  transition: transform 0.2s;
+
+  [aria-expanded='true'] > & {
+    transform: rotate(180deg);
+  }
+}
+
+.subList {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-menu-active);
+
+  @media (--lg) {
+    display: none;
+  }
+}
+
+.subLink {
+  display: block;
+  padding: 0.5rem 1rem 0.5rem 2rem;
   color: white;
   text-decoration: none;
   transition: background 0.2s;
@@ -27,6 +105,6 @@
   }
 
   &[aria-current='page'] {
-    background: var(--color-menu-active);
+    font-weight: bold;
   }
 }

--- a/src/components/Menu.module.css
+++ b/src/components/Menu.module.css
@@ -50,10 +50,10 @@
   }
 
   &[aria-current='page'] {
-    box-shadow: inset 0.25rem 0 0 white;
+    box-shadow: inset 0.25rem 0 0 var(--color-menu-accent);
 
     @media (--lg) {
-      box-shadow: inset 0 -0.25rem 0 white;
+      box-shadow: inset 0 -0.25rem 0 var(--color-menu-accent);
     }
   }
 }
@@ -109,6 +109,6 @@
   }
 
   &[aria-current='page'] {
-    box-shadow: inset 0.25rem 0 0 white;
+    box-shadow: inset 0.25rem 0 0 var(--color-menu-accent);
   }
 }

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -17,10 +17,11 @@ const links = [
 interface Props {
   open: boolean;
   onClose: () => void;
+  animate: boolean;
   subpages: MenuSubpages;
 }
 
-const Menu: React.FC<Props> = ({ open, onClose, subpages }) => {
+const Menu: React.FC<Props> = ({ open, onClose, animate, subpages }) => {
   const pathname = usePathname();
   // Expand the section of the current page by default
   const [expanded, setExpanded] = useState<string[]>(() => (pathname ? [`/${pathname.split('/')[1]}`] : []));
@@ -36,7 +37,7 @@ const Menu: React.FC<Props> = ({ open, onClose, subpages }) => {
   }
 
   return (
-    <div className={styles.root} data-mobile-open={open}>
+    <div className={styles.root} data-mobile-open={open} data-animate={animate}>
       <nav id="site-menu" aria-label="Huvudmeny" className={styles.nav}>
         {links.map(({ href, label, exact }) => {
           const items = subpages[href] ?? [];

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -36,63 +36,67 @@ const Menu: React.FC<Props> = ({ open, onClose, subpages }) => {
   }
 
   return (
-    <nav id="site-menu" aria-label="Huvudmeny" className={styles.root} data-mobile-open={open}>
-      {links.map(({ href, label, exact }) => {
-        const items = subpages[href] ?? [];
-        const isExpanded = expanded.includes(href);
-        const subListId = `site-menu-sub${href.replaceAll('/', '-')}`;
+    <div className={styles.root} data-mobile-open={open}>
+      <nav id="site-menu" aria-label="Huvudmeny" className={styles.nav}>
+        {links.map(({ href, label, exact }) => {
+          const items = subpages[href] ?? [];
+          const isExpanded = expanded.includes(href);
+          const subListId = `site-menu-sub${href.replaceAll('/', '-')}`;
 
-        return (
-          <div className={styles.group} key={href}>
-            <div className={styles.groupHeader}>
-              <Link
-                className={styles.navLink}
-                href={href}
-                aria-current={isActive(href, exact) ? 'page' : undefined}
-                onClick={onClose}
-              >
-                {label}
-              </Link>
-              {items.length > 0 && (
-                <button
-                  className={styles.expandToggle}
-                  aria-expanded={isExpanded}
-                  aria-controls={subListId}
-                  aria-label={`Undersidor för ${label}`}
-                  onClick={() => toggleExpanded(href)}
+          return (
+            <div className={styles.group} key={href}>
+              <div className={styles.groupHeader}>
+                <Link
+                  className={styles.navLink}
+                  href={href}
+                  aria-current={isActive(href, exact) ? 'page' : undefined}
+                  onClick={onClose}
                 >
-                  <svg className={styles.chevron} viewBox="0 0 16 16" width="16" height="16" aria-hidden>
-                    <path
-                      d="M3 6l5 5 5-5"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </button>
+                  {label}
+                </Link>
+                {items.length > 0 && (
+                  <button
+                    className={styles.expandToggle}
+                    aria-expanded={isExpanded}
+                    aria-controls={subListId}
+                    aria-label={`Undersidor för ${label}`}
+                    onClick={() => toggleExpanded(href)}
+                  >
+                    <svg className={styles.chevron} viewBox="0 0 16 16" width="16" height="16" aria-hidden>
+                      <path
+                        d="M3 6l5 5 5-5"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </button>
+                )}
+              </div>
+              {items.length > 0 && (
+                <div id={subListId} className={styles.subListWrapper} data-expanded={isExpanded}>
+                  <div className={styles.subList}>
+                    {items.map((item) => (
+                      <Link
+                        key={item.href}
+                        className={styles.subLink}
+                        href={item.href}
+                        aria-current={isActive(item.href, true) ? 'page' : undefined}
+                        onClick={onClose}
+                      >
+                        {item.label}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
               )}
             </div>
-            {items.length > 0 && isExpanded && (
-              <div id={subListId} className={styles.subList}>
-                {items.map((item) => (
-                  <Link
-                    key={item.href}
-                    className={styles.subLink}
-                    href={item.href}
-                    aria-current={isActive(item.href, true) ? 'page' : undefined}
-                    onClick={onClose}
-                  >
-                    {item.label}
-                  </Link>
-                ))}
-              </div>
-            )}
-          </div>
-        );
-      })}
-    </nav>
+          );
+        })}
+      </nav>
+    </div>
   );
 };
 

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import styles from './Menu.module.css';
 import { usePathname } from 'next/navigation';
+import { useState } from 'react';
+import { MenuSubpages } from '@/utils/navigationUtils';
 
 const links = [
   { href: '/', label: 'Hem', exact: true },
@@ -15,10 +17,13 @@ const links = [
 interface Props {
   open: boolean;
   onClose: () => void;
+  subpages: MenuSubpages;
 }
 
-const Menu: React.FC<Props> = ({ open, onClose }) => {
+const Menu: React.FC<Props> = ({ open, onClose, subpages }) => {
   const pathname = usePathname();
+  // Expand the section of the current page by default
+  const [expanded, setExpanded] = useState<string[]>(() => (pathname ? [`/${pathname.split('/')[1]}`] : []));
 
   function isActive(href: string, exact = false) {
     if (!pathname) return false;
@@ -26,19 +31,67 @@ const Menu: React.FC<Props> = ({ open, onClose }) => {
     return pathname === href || pathname.startsWith(`${href}/`);
   }
 
+  function toggleExpanded(href: string) {
+    setExpanded((prev) => (prev.includes(href) ? prev.filter((h) => h !== href) : [...prev, href]));
+  }
+
   return (
     <nav id="site-menu" aria-label="Huvudmeny" className={styles.root} data-mobile-open={open}>
-      {links.map(({ href, label, exact }) => (
-        <Link
-          className={styles.navLink}
-          key={href}
-          href={href}
-          aria-current={isActive(href, exact) ? 'page' : undefined}
-          onClick={onClose}
-        >
-          {label}
-        </Link>
-      ))}
+      {links.map(({ href, label, exact }) => {
+        const items = subpages[href] ?? [];
+        const isExpanded = expanded.includes(href);
+        const subListId = `site-menu-sub${href.replaceAll('/', '-')}`;
+
+        return (
+          <div className={styles.group} key={href}>
+            <div className={styles.groupHeader}>
+              <Link
+                className={styles.navLink}
+                href={href}
+                aria-current={isActive(href, exact) ? 'page' : undefined}
+                onClick={onClose}
+              >
+                {label}
+              </Link>
+              {items.length > 0 && (
+                <button
+                  className={styles.expandToggle}
+                  aria-expanded={isExpanded}
+                  aria-controls={subListId}
+                  aria-label={`Undersidor för ${label}`}
+                  onClick={() => toggleExpanded(href)}
+                >
+                  <svg className={styles.chevron} viewBox="0 0 16 16" width="16" height="16" aria-hidden>
+                    <path
+                      d="M3 6l5 5 5-5"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              )}
+            </div>
+            {items.length > 0 && isExpanded && (
+              <div id={subListId} className={styles.subList}>
+                {items.map((item) => (
+                  <Link
+                    key={item.href}
+                    className={styles.subLink}
+                    href={item.href}
+                    aria-current={isActive(item.href, true) ? 'page' : undefined}
+                    onClick={onClose}
+                  >
+                    {item.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
     </nav>
   );
 };

--- a/src/utils/navigationUtils.ts
+++ b/src/utils/navigationUtils.ts
@@ -1,0 +1,28 @@
+import { ContentfulPage } from '@/contentful/data';
+
+export interface MenuSubpage {
+  href: string;
+  label: string;
+}
+
+export type MenuSubpages = Record<string, MenuSubpage[]>;
+
+// Groups second-level pages (e.g. verksamhet/vargungar) under their root path
+// so the menu can show them as subitems. Deeper pages are left to sidebars and
+// content links.
+export function getMenuSubpages(pages: Pick<ContentfulPage, 'slug' | 'title'>[]): MenuSubpages {
+  const subpages: MenuSubpages = {};
+
+  for (const page of pages) {
+    const parts = page.slug.split('/');
+    if (parts.length !== 2) continue;
+    const root = `/${parts[0]}`;
+    (subpages[root] ??= []).push({ href: `/${page.slug}`, label: page.title });
+  }
+
+  for (const items of Object.values(subpages)) {
+    items.sort((a, b) => a.label.localeCompare(b.label, 'sv'));
+  }
+
+  return subpages;
+}


### PR DESCRIPTION
Improves mobile navigation by surfacing second-level pages in the menu, since the sidebar links are easy to miss below the content on mobile.

- Groups second-level pages (e.g. verksamhet/vargungar) under their top-level menu item, derived from Contentful page slugs
- Sections expand via a chevron button with proper aria attributes; the current section starts expanded
- Subpages are sorted with Swedish collation; desktop menu is unchanged
- The current page is indicated with a yellow accent bar (logo yellow) instead of a background color, so the dark red background is used only for the expanded submenu
- The mobile menu and submenus animate open and closed, using the widely supported grid-template-rows technique, with reduced-motion support
- Collapsed menu content is kept out of the tab order via visibility
- Navigating from the menu closes it instantly instead of animating, so the new page starts scrolled to the top